### PR TITLE
Refactor upper lip weight assignments

### DIFF
--- a/VRCFT - Quest OpenXR/QuestOpenXRTrackingModule.cs
+++ b/VRCFT - Quest OpenXR/QuestOpenXRTrackingModule.cs
@@ -204,10 +204,10 @@ namespace Meta_OpenXR
             unifiedExpressions[(int)UnifiedExpressions.MouthLowerDownLeft].Weight = weights[(int)ExpressionFB.LOWER_LIP_DEPRESSOR_L];
             unifiedExpressions[(int)UnifiedExpressions.MouthLowerDownRight].Weight = weights[(int)ExpressionFB.LOWER_LIP_DEPRESSOR_R];
 
-            unifiedExpressions[(int)UnifiedExpressions.MouthUpperUpLeft].Weight = Math.Max(0, weights[(int)ExpressionFB.UPPER_LIP_RAISER_L] - weights[(int)ExpressionFB.NOSE_WRINKLER_L]); // Workaround for upper lip up wierd tracking quirk.
-            unifiedExpressions[(int)UnifiedExpressions.MouthUpperDeepenLeft].Weight = Math.Max(0, weights[(int)ExpressionFB.UPPER_LIP_RAISER_L] - weights[(int)ExpressionFB.NOSE_WRINKLER_L]); // Workaround for upper lip up wierd tracking quirk.
-            unifiedExpressions[(int)UnifiedExpressions.MouthUpperUpRight].Weight = Math.Max(0, weights[(int)ExpressionFB.UPPER_LIP_RAISER_R] - weights[(int)ExpressionFB.NOSE_WRINKLER_R]); // Workaround for upper lip up wierd tracking quirk.
-            unifiedExpressions[(int)UnifiedExpressions.MouthUpperDeepenRight].Weight = Math.Max(0, weights[(int)ExpressionFB.UPPER_LIP_RAISER_R] - weights[(int)ExpressionFB.NOSE_WRINKLER_R]); // Workaround for upper lip up wierd tracking quirk.
+            unifiedExpressions[(int)UnifiedExpressions.MouthUpperUpLeft].Weight = weights[(int)ExpressionFB.UPPER_LIP_RAISER_L];
+            unifiedExpressions[(int)UnifiedExpressions.MouthUpperDeepenLeft].Weight = weights[(int)ExpressionFB.UPPER_LIP_RAISER_L];
+            unifiedExpressions[(int)UnifiedExpressions.MouthUpperUpRight].Weight = weights[(int)ExpressionFB.UPPER_LIP_RAISER_R];
+            unifiedExpressions[(int)UnifiedExpressions.MouthUpperDeepenRight].Weight = weights[(int)ExpressionFB.UPPER_LIP_RAISER_R];
 
             unifiedExpressions[(int)UnifiedExpressions.MouthRaiserUpper].Weight = weights[(int)ExpressionFB.CHIN_RAISER_T];
             unifiedExpressions[(int)UnifiedExpressions.MouthRaiserLower].Weight = weights[(int)ExpressionFB.CHIN_RAISER_B];


### PR DESCRIPTION
These adjustments seems to be done due to a bug in old Quest pro versions
For some reason all module developers have just copied that, and all avatars where not tracking upper lip properly
Tested on SteamLink Module with quest pro